### PR TITLE
Fixing a typo in the "set.tool" function

### DIFF
--- a/@SerialLink/SerialLink.m
+++ b/@SerialLink/SerialLink.m
@@ -535,7 +535,7 @@ end
 
         function set.tool(r, v)
             if isempty(v)
-                r.base = eye(4,4);
+                r.tool = eye(4,4);
             elseif ~ishomog(v)
                 error('tool must be a homogeneous transform');
             else


### PR DESCRIPTION
Noticed while working with version 9.10 that the "set.tool" function was setting the base matrix to eye(4) if an empty matrix is set on the tool matrix, instead of the tool matrix as it should be.