### PR TITLE
fixing typo and updating URL on Octave/README

### DIFF
--- a/Octave/README.txt
+++ b/Octave/README.txt
@@ -11,7 +11,7 @@ The latest version of octave can be found here: http://octave.sourceforge.net/
 Installation 
 ---------------------------------------------------------------------------------------------
 To install the toolbox in octave the latest version of RVCTools is needed you can get this 
-form https://petercorke.com/toolboxes/robotics-toolbox/
+from https://petercorke.com/toolboxes/robotics-toolbox/
 
 Unzip the toolbox and place it in the m directory in your octave install (share\octave\3.4.3\m)  
 

--- a/Octave/README.txt
+++ b/Octave/README.txt
@@ -11,7 +11,7 @@ The latest version of octave can be found here: http://octave.sourceforge.net/
 Installation 
 ---------------------------------------------------------------------------------------------
 To install the toolbox in octave the latest version of RVCTools is needed you can get this 
-form http://www.petercorke.com/Robotics_Toolbox.html
+form https://petercorke.com/toolboxes/robotics-toolbox/
 
 Unzip the toolbox and place it in the m directory in your octave install (share\octave\3.4.3\m)  
 

--- a/Octave/README.txt
+++ b/Octave/README.txt
@@ -4,7 +4,7 @@ Software
 This version of the toolbox was developed using Octave 3.4.3 for windows but should still 
 run on all distributions of octave. 
 
-The latest version of octave can be found here: http://octave.sourceforge.net/
+The latest version of octave can be found here: https://www.gnu.org/software/octave/download.html
 
 
 ---------------------------------------------------------------------------------------------


### PR DESCRIPTION
Fixing a typo and updating the Octave download URL and the robotics-toolbox URL